### PR TITLE
Fixed bug about returning the first contour without scanning all the …

### DIFF
--- a/Finger Detection and Tracking/FingerDetection.py
+++ b/Finger Detection and Tracking/FingerDetection.py
@@ -37,7 +37,7 @@ def max_contour(contour_list):
             max_area = area_cnt
             max_i = i
 
-        return contour_list[max_i]
+    return contour_list[max_i]
 
 
 def draw_rect(frame):


### PR DESCRIPTION
In the for loop that is supposed to scan all contours and record the index of the contour with the maximum area, there had been a bug that made the loop only run and return the first contour in the list immediately. I moved the return statement from the inside of the for loop to the outside, so the function will return only after the loop has finished.