### PR TITLE
Fix compatibility issue with newer OpenCV versions

### DIFF
--- a/Finger Detection and Tracking/FingerDetection.py
+++ b/Finger Detection and Tracking/FingerDetection.py
@@ -20,7 +20,7 @@ def rescale_frame(frame, wpercent=130, hpercent=130):
 def contours(hist_mask_image):
     gray_hist_mask_image = cv2.cvtColor(hist_mask_image, cv2.COLOR_BGR2GRAY)
     ret, thresh = cv2.threshold(gray_hist_mask_image, 0, 255, 0)
-    _, cont, hierarchy = cv2.findContours(thresh, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
+    cont, hierarchy = cv2.findContours(thresh, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
     return cont
 
 


### PR DESCRIPTION
In newer OpenCV versions, the function `findCountours` only returns two values, contours and hierarchy, instead of the three values returned previously.
See the [docs](https://docs.opencv.org/2.4/modules/imgproc/doc/structural_analysis_and_shape_descriptors.html#findcontours) for more information.